### PR TITLE
Corrige link para usar to ao invés de href

### DIFF
--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -189,7 +189,7 @@ export default function Menu() {
                   <ListItemText primary="Perguntas Frequentes" />
                 </ListItem>
               </Link>
-              <Link href="/userManual">
+              <Link to="/userManual">
                 <ListItem button key="Manual de Uso">
                   <ListItemIcon>
                     <LibraryBooksIcon />


### PR DESCRIPTION
Usar `href` em <Link /> quebrava totalmente a home.